### PR TITLE
Add 'lib' dir to CRYSTAL_PATH for crystal-0.20 (shards-0.7)

### DIFF
--- a/lib/CrystalBuild/Builder/Shards.pm
+++ b/lib/CrystalBuild/Builder/Shards.pm
@@ -53,7 +53,7 @@ __DATA__
 
 set -e
 
-export CRYSTAL_PATH={{crystal_dir}}/libs:{{crystal_dir}}/src:.
+export CRYSTAL_PATH={{crystal_dir}}/libs:{{crystal_dir}}/src:{{crystal_dir}}/lib:.
 export LIBRARY_PATH={{target_dir}}:/usr/local/lib:$LIBRARY_PATH
 export LD_LIBRARY_PATH={{target_dir}}:/usr/local/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
Failed to require shards-libs in crystal-0.20.0 due to shards-0.7 changes its path from `libs` to `lib` .

### crystal-0.20.0 (crenv)

```shell
% crystal eval 'p {{env("CRYSTAL_PATH")}}'
"/home/maiha/.crenv/versions/0.20.0/src:libs"
```

### crystal-0.20.0 (official)

```shell
% crystal eval 'p {{env("CRYSTAL_PATH")}}'
Using compiled compiler at .build/crystal
"/home/maiha/git/maiha/crystal/src:libs:lib"
```

Although I don't know this fix is a right way, it should be needed some hack like this.
Thanks.
