### PR TITLE
Support Crystal 0.25.1

### DIFF
--- a/bin/crenv-install
+++ b/bin/crenv-install
@@ -51,7 +51,6 @@ indent() {
 parse_options "$@"
 WITHOUT_RELEASE=0
 for option in "${OPTIONS[@]}"; do
-  echo $option;
   case "$option" in
   "l" | "list" )
     echo "Available versions:"

--- a/bin/crenv-install
+++ b/bin/crenv-install
@@ -3,9 +3,10 @@
 # Summary: Install a Crystal version using the crystal-build plugin
 #
 # Usage: crenv install <version>
-#        crenv install -l|--list
+#        crenv install -l|--list|--without-release
 #
 #   -l/--list        List all available versions
+#   --without-release  Do not build the compiler in release mode
 #
 set -e
 [ -n "$CRENV_DEBUG" ] && set -x
@@ -48,12 +49,17 @@ indent() {
 }
 
 parse_options "$@"
+WITHOUT_RELEASE=0
 for option in "${OPTIONS[@]}"; do
+  echo $option;
   case "$option" in
   "l" | "list" )
     echo "Available versions:"
     definitions | indent
     exit
+    ;;
+  "without-release" )
+    WITHOUT_RELEASE=1
     ;;
   esac
 done
@@ -139,7 +145,7 @@ trap cleanup SIGINT
 
 # Invoke `crystal-build` and record the exit status in $STATUS.
 STATUS=0
-crystal-build "$DEFINITION" "$PREFIX" || STATUS="$?"
+crystal-build "$DEFINITION" "$PREFIX" "$WITHOUT_RELEASE" || STATUS="$?"
 
 # Display a more helpful message if the definition wasn't found.
 if [ "$STATUS" == "2" ]; then

--- a/bin/crystal-build
+++ b/bin/crystal-build
@@ -27,13 +27,13 @@ sub main {
     my $shards_url = $share_url.'/shards.json';
 
     my $crenv = CrystalBuild->new(
-        prefix      => $args->{prefix},
-        cache       => $args->{cache},
-        cache_url   => $cache_url,
-        shards_url  => $shards_url,
-        cache_dir   => abs_path($cache_dir),
-        fetcher     => HTTP::Command::Wrapper->create,
-        github_repo => $github_repo,
+        prefix          => $args->{prefix},
+        cache           => $args->{cache},
+        cache_url       => $cache_url,
+        shards_url      => $shards_url,
+        cache_dir       => abs_path($cache_dir),
+        fetcher         => HTTP::Command::Wrapper->create,
+        github_repo     =>  $github_repo,
         without_release => $args->{without_release},
     );
 

--- a/bin/crystal-build
+++ b/bin/crystal-build
@@ -34,6 +34,7 @@ sub main {
         cache_dir   => abs_path($cache_dir),
         fetcher     => HTTP::Command::Wrapper->create,
         github_repo => $github_repo,
+        without_release => $args->{without_release},
     );
 
     if ($args->{definitions}) {

--- a/lib/CrystalBuild.pm
+++ b/lib/CrystalBuild.pm
@@ -51,6 +51,7 @@ sub shards_installer {
         fetcher          => $self->{fetcher},
         remote_cache_url => $self->{shards_url},
         cache_dir        => $self->{cache_dir},
+        without_release  => $self->{without_release},
     );
     return $installer;
 }

--- a/lib/CrystalBuild/Builder/Shards.pm
+++ b/lib/CrystalBuild/Builder/Shards.pm
@@ -8,9 +8,11 @@ use Text::Caml;
 use CrystalBuild::Utils;
 
 sub new {
-    my $class = shift;
-    return bless {} => $class;
+    my ($class, %opt) = @_;
+    bless { %opt } => $class;
 }
+
+sub without_release  { shift->{without_release} }
 
 sub build {
     my ($self, $target_dir, $crystal_dir) = @_;
@@ -43,6 +45,7 @@ sub _create_build_script {
         target_dir  => $target_dir,
         platform    => $platform,
         link_flags  => $no_pie_fg ? '-no-pie' : '',
+        without_release_flags => $self->without_release ? '' : '--release --no-debug',
     };
 
     return Text::Caml->new->render($template, $params);
@@ -97,7 +100,7 @@ fi
 cd "{{target_dir}}"
 
 if [ -z "{{link_flags}}" ]; then
-    "{{crystal_dir}}/bin/crystal" build --release src/shards.cr -o bin/shards
+    "{{crystal_dir}}/bin/crystal" build src/shards.cr -o bin/shards {{without_release_flags}}
 else
-    "{{crystal_dir}}/bin/crystal" build --release src/shards.cr -o bin/shards --link-flags "{{link_flags}}"
+    "{{crystal_dir}}/bin/crystal" build src/shards.cr -o bin/shards --link-flags "{{link_flags}}" {{without_release_flags}}
 fi

--- a/lib/CrystalBuild/Builder/Shards.pm
+++ b/lib/CrystalBuild/Builder/Shards.pm
@@ -41,10 +41,10 @@ sub _create_build_script {
     my ($platform) = CrystalBuild::Utils::system_info();
     my $template   = $self->_get_data_section;
     my $params     = {
-        crystal_dir => abs_path($crystal_dir),
-        target_dir  => $target_dir,
-        platform    => $platform,
-        link_flags  => $no_pie_fg ? '-no-pie' : '',
+        crystal_dir           => abs_path($crystal_dir),
+        target_dir            => $target_dir,
+        platform              => $platform,
+        link_flags            => $no_pie_fg ? '-no-pie' : '',
         without_release_flags => $self->without_release ? '' : '--release --no-debug',
     };
 

--- a/lib/CrystalBuild/Installer/Shards.pm
+++ b/lib/CrystalBuild/Installer/Shards.pm
@@ -20,6 +20,7 @@ sub new {
 sub fetcher          { shift->{fetcher} }
 sub remote_cache_url { shift->{remote_cache_url} }
 sub cache_dir        { shift->{cache_dir} }
+sub without_release  { shift->{without_release} }
 
 sub install {
     my ($self, $crystal_version, $crystal_dir) = @_;
@@ -69,7 +70,9 @@ sub _download {
 
 sub _build {
     my ($self, $target_dir, $crystal_dir) = @_;
-    return CrystalBuild::Builder::Shards->new->build($target_dir, $crystal_dir);
+    return CrystalBuild::Builder::Shards->new(
+        without_release => $self->without_release,
+    )->build($target_dir, $crystal_dir);
 }
 
 sub _copy {

--- a/lib/CrystalBuild/Utils.pm
+++ b/lib/CrystalBuild/Utils.pm
@@ -53,7 +53,7 @@ sub extract_tar {
 }
 
 sub parse_args {
-    my ($version, $prefix) = @_[-2,-1];
+    my ($version, $prefix, $without_release) = @_[-3,-2,-1];
     my $definitions = 0;
     my $cache       = 1;
 
@@ -67,6 +67,7 @@ sub parse_args {
         prefix      => $prefix,
         definitions => $definitions,
         cache       => $cache,
+        without_release => $without_release,
     };
 }
 

--- a/lib/CrystalBuild/Utils.pm
+++ b/lib/CrystalBuild/Utils.pm
@@ -63,10 +63,10 @@ sub parse_args {
     );
 
     return {
-        version     => $version,
-        prefix      => $prefix,
-        definitions => $definitions,
-        cache       => $cache,
+        version         => $version,
+        prefix          => $prefix,
+        definitions     => $definitions,
+        cache           => $cache,
         without_release => $without_release,
     };
 }

--- a/share/crystal-build/releases.json
+++ b/share/crystal-build/releases.json
@@ -1,5 +1,16 @@
 [
   {
+    "tag_name": "0.25.1",
+    "assets": {
+      "linux-x86": "https://github.com/crystal-lang/crystal/releases/download/0.25.1/crystal-0.25.1-1-linux-i686.tar.gz",
+      "linux-x64": "https://github.com/crystal-lang/crystal/releases/download/0.25.1/crystal-0.25.1-1-linux-x86_64.tar.gz",
+      "darwin-x64": "https://github.com/crystal-lang/crystal/releases/download/0.25.1/crystal-0.25.1-1-darwin-x86_64.tar.gz",
+      "darwin-x64-high_sierra": "https://homebrew.bintray.com/bottles/crystal-lang-0.25.1_1.high_sierra.bottle.tar.gz",
+      "darwin-x64-sierra": "https://homebrew.bintray.com/bottles/crystal-lang-0.25.1_1.sierra.bottle.tar.gz",
+      "darwin-x64-el_capitan": "https://homebrew.bintray.com/bottles/crystal-lang-0.25.1_1.el_capitan.bottle.tar.gz"
+    }
+  },
+  {
     "tag_name": "0.25.0",
     "assets": {
       "linux-x86": "https://github.com/crystal-lang/crystal/releases/download/0.25.0/crystal-0.25.0-1-linux-i686.tar.gz",

--- a/share/crystal-build/shards.json
+++ b/share/crystal-build/shards.json
@@ -1,5 +1,6 @@
 {
   "default": "https://github.com/crystal-lang/shards/archive/master.tar.gz",
+  "0.25.1": "https://github.com/crystal-lang/shards/archive/v0.8.1.tar.gz",
   "0.23.1": "https://github.com/crystal-lang/shards/archive/v0.7.1.tar.gz",
   "0.23.0": "https://github.com/crystal-lang/shards/archive/v0.7.1.tar.gz",
   "0.22.0": "https://github.com/crystal-lang/shards/archive/v0.7.1.tar.gz",

--- a/t/crystal_build/builder/shards/new.t
+++ b/t/crystal_build/builder/shards/new.t
@@ -2,13 +2,22 @@ use strict;
 use warnings;
 use utf8;
 
+use Test::MockObject;
+
 use t::Util;
 
 use CrystalBuild::Builder::Shards;
 
 subtest basic => sub {
-    my $self = CrystalBuild::Builder::Shards->new;
+    my $without_release = Test::MockObject->new;
+
+    my $self = CrystalBuild::Builder::Shards->new(
+        without_release  => $without_release,
+    );
+
     isa_ok $self, 'CrystalBuild::Builder::Shards';
+
+    is $self->without_release, $without_release;
 };
 
 done_testing;

--- a/t/crystal_build/installer/shards/new.t
+++ b/t/crystal_build/installer/shards/new.t
@@ -12,11 +12,13 @@ subtest basic => sub {
     my $fetcher          = Test::MockObject->new;
     my $remote_cache_url = Test::MockObject->new;
     my $cache_dir        = Test::MockObject->new;
+    my $without_release  = Test::MockObject->new;
 
     my $installer = CrystalBuild::Installer::Shards->new(
         fetcher          => $fetcher,
         remote_cache_url => $remote_cache_url,
         cache_dir        => $cache_dir,
+        without_release  => $without_release,
     );
 
     isa_ok $installer, 'CrystalBuild::Installer::Shards';
@@ -24,6 +26,7 @@ subtest basic => sub {
     is $installer->fetcher,          $fetcher;
     is $installer->remote_cache_url, $remote_cache_url;
     is $installer->cache_dir,        $cache_dir;
+    is $installer->without_release,  $without_release;
 };
 
 done_testing;

--- a/t/crystal_build/new.t
+++ b/t/crystal_build/new.t
@@ -12,13 +12,13 @@ subtest basic => sub {
     my $without_release = Test::MockObject->new;
 
     my $crenv = CrystalBuild->new(
-        test_key => 'test_value',
-        without_release  => $without_release,
+        test_key        => 'test_value',
+        without_release => $without_release,
     );
 
     isa_ok $crenv, 'CrystalBuild';
 
-    is $crenv->{test_key}, 'test_value';
+    is $crenv->{test_key},        'test_value';
     is $crenv->{without_release}, $without_release;
 };
 

--- a/t/crystal_build/new.t
+++ b/t/crystal_build/new.t
@@ -2,15 +2,24 @@ use strict;
 use warnings;
 use utf8;
 
+use Test::MockObject;
+
 use t::Util;
 
 use CrystalBuild;
 
 subtest basic => sub {
-    my $crenv = CrystalBuild->new(test_key => 'test_value');
+    my $without_release = Test::MockObject->new;
+
+    my $crenv = CrystalBuild->new(
+        test_key => 'test_value',
+        without_release  => $without_release,
+    );
 
     isa_ok $crenv, 'CrystalBuild';
+
     is $crenv->{test_key}, 'test_value';
+    is $crenv->{without_release}, $without_release;
 };
 
 done_testing;

--- a/t/crystal_build/utils/parse_args.t
+++ b/t/crystal_build/utils/parse_args.t
@@ -7,9 +7,10 @@ use t::Util;
 use CrystalBuild::Utils;
 
 subtest basic => sub {
-    my $args = CrystalBuild::Utils::parse_args('0.7.4', 'prefix');
+    my $args = CrystalBuild::Utils::parse_args('0.7.4', 'prefix', '1');
     is $args->{version}, '0.7.4';
     is $args->{prefix}, 'prefix';
+    is $args->{without_release}, '1';
     ok not $args->{definitions};
 };
 

--- a/t/crystal_build/utils/parse_args.t
+++ b/t/crystal_build/utils/parse_args.t
@@ -8,8 +8,8 @@ use CrystalBuild::Utils;
 
 subtest basic => sub {
     my $args = CrystalBuild::Utils::parse_args('0.7.4', 'prefix', '1');
-    is $args->{version}, '0.7.4';
-    is $args->{prefix}, 'prefix';
+    is $args->{version},         '0.7.4';
+    is $args->{prefix},          'prefix';
     is $args->{without_release}, '1';
     ok not $args->{definitions};
 };


### PR DESCRIPTION
I tried to install Crystal 0.25.1 by using crenv. But I got the following error.

```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.13.5
BuildVersion:	17F77
$ crenv -v
crenv 1.1.0-7-gdd7cd67
$ crenv install 0.25.1
(some outputs...)
Building Shards ... Assertion failed: (cast<DISubprogram>(Scope)->describes(MF->getFunction())), function getOrCreateRegularScope, file /var/cache/omnibus/src/llvm/llvm-3.9.1.src/lib/CodeGen/LexicalScopes.cpp, line 159.
/Users/shimbaco/.anyenv/envs/crenv/versions/0.25.1/bin/crystal: line 102: 53504 Abort trap: 6           "$INSTALL_DIR/embedded/bin/crystal" "$@"
```

When I looked up a cause, I found this issue. https://github.com/crystal-lang/crystal/issues/4719
It seems that the `--release` and `--no-debug` options should be attached together. And Homebrew seems to have done that.
https://github.com/Homebrew/homebrew-core/blob/23f180fc4587e5d1b8e5aaaa9278315541f4466c/Formula/crystal-lang.rb#L63

This PR is to fix this problem.